### PR TITLE
fix: validate source directory and correctly move archive to destination

### DIFF
--- a/src/main/java/io/github/devcavin/domain/entity/Archive.java
+++ b/src/main/java/io/github/devcavin/domain/entity/Archive.java
@@ -9,16 +9,22 @@ public class Archive {
     private final UUID id;
     private final UUID backupJobId;
     private final Path path;
+    private final Path destinationDirectory;
     private final Long sizeInBytes;
     private final Instant creationAt;
 
 
-    public Archive(UUID backupJobId, Path path, Long sizeInBytes) {
+    public Archive(UUID backupJobId, Path path, Path destinationDirectory, Long sizeInBytes) {
         this.id = UUID.randomUUID();
         this.backupJobId = Objects.requireNonNull(backupJobId);
-        this.path = path;
+        this.path = Objects.requireNonNull(path);
+        this.destinationDirectory = destinationDirectory;
         this.sizeInBytes = sizeInBytes;
         this.creationAt = Instant.now();
+    }
+
+    public Path getDestinationDirectory() {
+        return destinationDirectory;
     }
 
     public Path getPath() {

--- a/src/main/java/io/github/devcavin/domain/valueobject/SourcePath.java
+++ b/src/main/java/io/github/devcavin/domain/valueobject/SourcePath.java
@@ -23,6 +23,10 @@ public class SourcePath {
             throw new IllegalArgumentException("Source path is not readable: %s".formatted(resolvePath));
         }
 
+        if (!Files.isDirectory(resolvePath)) {
+            throw new IllegalArgumentException("Source path is not a directory: %s".formatted(resolvePath));
+        }
+
         this.path = resolvePath;
     }
 

--- a/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveCreator.java
+++ b/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveCreator.java
@@ -4,46 +4,59 @@ import io.github.devcavin.domain.entity.Archive;
 import io.github.devcavin.domain.entity.BackupJob;
 import io.github.devcavin.domain.service.ArchiveCreator;
 
-import java.io.FileOutputStream;
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 public class LocalArchiveCreator implements ArchiveCreator {
+
     @Override
-    public Archive createArchive(BackupJob backupJob) {
+    public Archive createArchive(BackupJob job) {
+        Path source = job.getSourcePath().getPath();
+
         try {
-            Path sourcePath = backupJob.getSourcePath().getPath();
             Path tempFile = Files.createTempFile("backup-", ".zip");
 
-            try(ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(tempFile.toFile()))) {
-                Files.walk(sourcePath)
-                        .filter(path -> !Files.isDirectory(sourcePath))
-                        .forEach(path -> addToZip(sourcePath, path, zos));
+            try (Stream<Path> paths = Files.walk(source);
+                 ZipOutputStream zos =
+                         new ZipOutputStream(Files.newOutputStream(tempFile))) {
+
+                paths
+                        .filter(Files::isRegularFile)
+                        .forEach(path -> addToZip(source, path, zos));
             }
 
             long size = Files.size(tempFile);
 
             return new Archive(
-                    backupJob.getId(),
+                    job.getId(),
                     tempFile,
+                    job.getDestinationPath().getPath(),
                     size
             );
+
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create archive.", e);
+            throw new RuntimeException("Failed to create archive", e);
         }
     }
 
     private void addToZip(Path root, Path file, ZipOutputStream zos) {
         try {
-            ZipEntry entry = new ZipEntry(root.relativize(root).toString());
+            String entryName = root
+                    .relativize(file)
+                    .toString()
+                    .replace(File.separatorChar, '/');
+
+            ZipEntry entry = new ZipEntry(entryName);
             zos.putNextEntry(entry);
             Files.copy(file, zos);
             zos.closeEntry();
+
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to add file to zip: " + file, e);
         }
     }
 }

--- a/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveStorage.java
+++ b/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveStorage.java
@@ -12,12 +12,12 @@ public class LocalArchiveStorage implements ArchiveStorage {
     @Override
     public void store(Archive archive) {
         try {
-            Path destinationDirectory = archive.getPath().getParent();
+            Path destinationDirectory = archive.getDestinationDirectory().getParent();
             Files.createDirectories(destinationDirectory);
 
-            Path finalPath = destinationDirectory.resolve(archive.getPath().getFileName());
+            Path finalPath = destinationDirectory.resolve(archive.getDestinationDirectory().getFileName());
 
-            Files.move(archive.getPath(), finalPath, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(archive.getDestinationDirectory(), finalPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new RuntimeException("Failed to store archive", e);
         }


### PR DESCRIPTION
This pull request introduces improvements to the archive creation and storage process, focusing on better handling of file paths, enforcing directory validation, and refactoring for clarity and correctness. The changes ensure that source paths are validated as directories, archives are created and referenced with explicit destination directories, and file handling is more robust.

**Archive creation and storage improvements:**

* The `Archive` entity now includes a `destinationDirectory` property, and its constructor and getter have been updated to require and expose this information. This makes the destination of each archive explicit and accessible.
* The `LocalArchiveCreator` implementation has been refactored to:
  - Use streams and NIO methods for file traversal and zip creation.
  - Pass the backup job's destination path to the new `Archive` constructor.
  - Improve error handling and ensure zip entries use POSIX-style paths.
* The `LocalArchiveStorage` class now uses the `destinationDirectory` property from the `Archive` entity to determine where to store the archive, ensuring consistency and correctness in file placement.

**Validation enhancements:**

* The `SourcePath` value object constructor now validates that the provided path is a directory, throwing an exception if not. This prevents invalid source paths from being used in backup jobs.

Closes #2