### PR TITLE
fix: local archive storage to move actual file path to destination file path

### DIFF
--- a/src/main/java/io/github/devcavin/App.java
+++ b/src/main/java/io/github/devcavin/App.java
@@ -56,7 +56,7 @@ public class App {
         // Demo
         UUID jobId = createJob.execute(
                 "demo-backup",
-                "/home/cavin/Documents",
+                "/home/cavin/Documents/demo-backup",
                 "/home/cavin/backups"
         );
 

--- a/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveStorage.java
+++ b/src/main/java/io/github/devcavin/infrastructure/archive/local/LocalArchiveStorage.java
@@ -12,12 +12,14 @@ public class LocalArchiveStorage implements ArchiveStorage {
     @Override
     public void store(Archive archive) {
         try {
-            Path destinationDirectory = archive.getDestinationDirectory().getParent();
+            Path destinationDirectory = archive.getDestinationDirectory();
             Files.createDirectories(destinationDirectory);
 
-            Path finalPath = destinationDirectory.resolve(archive.getDestinationDirectory().getFileName());
+            String filename = String.format("backup-%d.zip", System.currentTimeMillis());
+            Path finalPath = destinationDirectory.resolve(filename);
 
-            Files.move(archive.getDestinationDirectory(), finalPath, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(archive.getPath(), finalPath, StandardCopyOption.REPLACE_EXISTING);
+
         } catch (IOException e) {
             throw new RuntimeException("Failed to store archive", e);
         }


### PR DESCRIPTION
This pull request introduces improvements to the backup storage process and updates the demo backup directory path. The most important changes are grouped below:

Backup storage improvements:

* Changed the backup storage logic in `LocalArchiveStorage.store` to create the destination directory directly (instead of its parent), and to generate a unique backup filename using the current timestamp, ensuring backups are not overwritten and are more easily identifiable.
* Modified the file move operation in `LocalArchiveStorage.store` to move the archive from its temporary path to the newly generated backup file within the destination directory, replacing any existing file if necessary.

Demo backup directory update:

* Updated the demo backup directory path in `App.main` to use a specific subdirectory (`/home/cavin/Documents/demo-backup`) for improved organization and clarity

Closes #1